### PR TITLE
fix shared ext build

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,8 +1,5 @@
 dnl Note: see README for build details
 
-PHP_ARG_ENABLE(mysql-xdevapi, whether to enable mysql-xdevapi,
-	[  --enable-mysql-xdevapi       Enable mysql-xdevapi], no, yes)
-
 PHP_ARG_ENABLE(mysql-xdevapi-experimental-features, whether to disable experimental features in mysql-xdevapi,
 	[  --disable-mysql-xdevapi-experimental-features
 						Disable support for the experimental features in mysql-xdevapi], yes, no)
@@ -16,6 +13,9 @@ PHP_ARG_WITH(boost, for boost install dir,
 
 PHP_ARG_WITH(protobuf, for protobuf install dir,
 	[  --with-protobuf[=DIR]          Point out protobuf library])
+
+PHP_ARG_ENABLE(mysql-xdevapi, whether to enable mysql-xdevapi,
+	[  --enable-mysql-xdevapi       Enable mysql-xdevapi], no, yes)
 
 
 dnl If some extension uses mysql-xdevapi it will get compiled in PHP core


### PR DESCRIPTION
ATM one can't build the extension as shared if json and/or mysqlnd are shared, even if --enable-mysql-xdevapi=shared is used.

The problem is that every PHP_ARG_WITH overwrites previously set ext_shared, as can be seen in acinclude.m4:
```
dnl PHP_ARG_WITH(arg-name, check message, help text[, default-val[, extension-or-not]])
dnl Sets PHP_ARG_NAME either to the user value or to the default value.
dnl default-val defaults to no.  This will also set the variable ext_shared,
dnl and will overwrite any previous variable of that name.
```

ext_shared is then checked by PHP_ADD_EXTENSION_DEP, which fails with error stating that since this extension is built staticallly, the other extensions have to be built statically as well.

Admittedly, the proposed solution is more of a hack, another option would be to specify 2 lib prefixes in the same time for --with-mysql-xdevapi, but that isn't supported either, so here we are =/