### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,4 +1,3 @@
-// $Id$
 // vim:ft=javascript
 
 // Note: see README for build details


### PR DESCRIPTION
The $Id$ keywords were used in Subversion where they can be substituted
with filename, last revision number change, last changed date, and last
user who changed it.

In Git this functionality is different and can be done with Git attribute
ident. These need to be defined manually for each file in the
.gitattributes file and are afterwards replaced with 40-character
hexadecimal blob object name which is based only on the particular file
contents.

This patch simplifes handling of $Id$ keywords by removing them since
they are not used anymore.

Thanks for considering merging this or checking it out.