### PR TITLE
fix for 7.3.0alpha4

### DIFF
--- a/mysqlx_base_result_iterator.cc
+++ b/mysqlx_base_result_iterator.cc
@@ -193,7 +193,9 @@ void
 mysqlx_register_base_result_iterator(zend_class_entry * ce)
 {
 	ce->get_iterator = mysqlx_base_result_create_iterator;
+#if PHP_VERSION_ID < 70300
 	ce->iterator_funcs.funcs = &mysqlx_base_result_iterator_funcs;
+#endif
 
 	zend_class_implements(ce, 1, zend_ce_traversable);
 }

--- a/mysqlx_doc_result_iterator.cc
+++ b/mysqlx_doc_result_iterator.cc
@@ -198,7 +198,9 @@ void
 mysqlx_register_doc_result_iterator(zend_class_entry * ce)
 {
 	ce->get_iterator = mysqlx_doc_result_create_iterator;
+#if PHP_VERSION_ID < 70300
 	ce->iterator_funcs.funcs = &mysqlx_doc_result_iterator_funcs;
+#endif
 
 	zend_class_implements(ce, 1, zend_ce_traversable);
 }

--- a/mysqlx_result_iterator.cc
+++ b/mysqlx_result_iterator.cc
@@ -192,7 +192,9 @@ void
 mysqlx_register_result_iterator(zend_class_entry * ce)
 {
 	ce->get_iterator = mysqlx__result_create_iterator;
+#if PHP_VERSION_ID < 70300
 	ce->iterator_funcs.funcs = &mysqlx__result_iterator_funcs;
+#endif
 
 	zend_class_implements(ce, 1, zend_ce_traversable);
 }

--- a/mysqlx_row_result_iterator.cc
+++ b/mysqlx_row_result_iterator.cc
@@ -192,7 +192,9 @@ void
 mysqlx_register_row_result_iterator(zend_class_entry * ce)
 {
 	ce->get_iterator = mysqlx_row_result_create_iterator;
+#if PHP_VERSION_ID < 70300
 	ce->iterator_funcs.funcs = &mysqlx_row_result_iterator_funcs;
+#endif
 
 	zend_class_implements(ce, 1, zend_ce_traversable);
 }

--- a/mysqlx_sql_statement_result_iterator.cc
+++ b/mysqlx_sql_statement_result_iterator.cc
@@ -191,7 +191,9 @@ void
 mysqlx_register_sql_statement_result_iterator(zend_class_entry * ce)
 {
 	ce->get_iterator = mysqlx_sql_result_create_iterator;
+#if PHP_VERSION_ID < 70300
 	ce->iterator_funcs.funcs = &mysqlx_sql_result_iterator_funcs;
+#endif
 
 	zend_class_implements(ce, 1, zend_ce_traversable);
 }


### PR DESCRIPTION
From UPGRADING.INTERNALS

```
 w. zend_class_entry.iterator_funcs have been replaced by iterator_funcs_ptr.
    You don't have to set its value, setting parent.funcs in the get_iterator
    function is enough.

```