### PR TITLE
fix for 7.4

### DIFF
--- a/messages/mysqlx_resultset__data_row.cc
+++ b/messages/mysqlx_resultset__data_row.cc
@@ -258,15 +258,15 @@ MYSQL_XDEVAPI_PHP_METHOD(mysqlx_data_row, decode)
 					}
 					do {
 						if (!util::pb::read_variant_64(input_stream, &neg)) break;
-						DBG_INF_FMT("neg  =" MYSQLND_LLU_SPEC, neg);
+						DBG_INF_FMT("neg  =" PRIu64, neg);
 						if (!util::pb::read_variant_64(input_stream, &hours)) break;
-						DBG_INF_FMT("hours=" MYSQLND_LLU_SPEC, hours);
+						DBG_INF_FMT("hours=" PRIu64, hours);
 						if (!util::pb::read_variant_64(input_stream, &minutes)) break;
-						DBG_INF_FMT("mins =" MYSQLND_LLU_SPEC, minutes);
+						DBG_INF_FMT("mins =" PRIu64, minutes);
 						if (!util::pb::read_variant_64(input_stream, &seconds)) break;
-						DBG_INF_FMT("secs =" MYSQLND_LLU_SPEC, seconds);
+						DBG_INF_FMT("secs =" PRIu64, seconds);
 						if (!util::pb::read_variant_64(input_stream, &useconds)) break;
-						DBG_INF_FMT("usecs=" MYSQLND_LLU_SPEC, useconds);
+						DBG_INF_FMT("usecs=" PRIu64, useconds);
 					} while (0);
 					#define TIME_FMT_STR "%s%02u:%02u:%02u.%08u"
 					ZVAL_NEW_STR(&zv, strpprintf(0, TIME_FMT_STR , neg? "-":"",
@@ -296,19 +296,19 @@ MYSQL_XDEVAPI_PHP_METHOD(mysqlx_data_row, decode)
 					}
 					do {
 						if (!util::pb::read_variant_64(input_stream, &year)) break;
-						DBG_INF_FMT("year =" MYSQLND_LLU_SPEC, year);
+						DBG_INF_FMT("year =" PRIu64, year);
 						if (!util::pb::read_variant_64(input_stream, &month)) break;
-						DBG_INF_FMT("month=" MYSQLND_LLU_SPEC, month);
+						DBG_INF_FMT("month=" PRIu64, month);
 						if (!util::pb::read_variant_64(input_stream, &day)) break;
-						DBG_INF_FMT("day  =" MYSQLND_LLU_SPEC, day);
+						DBG_INF_FMT("day  =" PRIu64, day);
 						if (!util::pb::read_variant_64(input_stream, &hours)) break;
-						DBG_INF_FMT("hours=" MYSQLND_LLU_SPEC, hours);
+						DBG_INF_FMT("hours=" PRIu64, hours);
 						if (!util::pb::read_variant_64(input_stream, &minutes)) break;
-						DBG_INF_FMT("mins =" MYSQLND_LLU_SPEC, minutes);
+						DBG_INF_FMT("mins =" PRIu64, minutes);
 						if (!util::pb::read_variant_64(input_stream, &seconds)) break;
-						DBG_INF_FMT("secs =" MYSQLND_LLU_SPEC, seconds);
+						DBG_INF_FMT("secs =" PRIu64, seconds);
 						if (!util::pb::read_variant_64(input_stream, &useconds)) break;
-						DBG_INF_FMT("usecs=" MYSQLND_LLU_SPEC, useconds);
+						DBG_INF_FMT("usecs=" PRIu64, useconds);
 					} while (0);
 					#define DATETIME_FMT_STR "%04u-%02u-%02u %02u:%02u:%02u"
 					ZVAL_NEW_STR(&zv, strpprintf(0, DATETIME_FMT_STR ,

--- a/mysqlx_class_properties.cc
+++ b/mysqlx_class_properties.cc
@@ -126,7 +126,11 @@ mysqlx_property_get_value(zval * object, zval * member, int type, void ** cache_
 
 
 /* {{{ mysqlx_property_set_value */
+#if PHP_VERSION_ID >= 70400
+zval *
+#else
 void
+#endif
 mysqlx_property_set_value(zval * object, zval * member, zval * value, void **cache_slot)
 {
 	zval tmp_member;
@@ -158,7 +162,11 @@ mysqlx_property_set_value(zval * object, zval * member, zval * value, void **cac
 	if (member == &tmp_member) {
 		zval_dtor(member);
 	}
+#if PHP_VERSION_ID >= 70400
+	DBG_RETURN(value);
+#else
 	DBG_VOID_RETURN;
+#endif
 }
 /* }}} */
 

--- a/mysqlx_class_properties.h
+++ b/mysqlx_class_properties.h
@@ -45,7 +45,11 @@ struct st_mysqlx_property
 void mysqlx_add_properties(HashTable * ht, const st_mysqlx_property_entry* entries);
 
 zval * mysqlx_property_get_value(zval * object, zval * member, int type, void ** cache_slot, zval * rv);
+#if PHP_VERSION_ID >= 70400
+zval *mysqlx_property_set_value(zval * object, zval * member, zval * value, void ** cache_slot);
+#else
 void mysqlx_property_set_value(zval * object, zval * member, zval * value, void ** cache_slot);
+#endif
 int mysqlx_object_has_property(zval * object, zval *member, int has_set_exists, void ** cache_slot);
 
 void mysqlx_free_property_cb(zval *el);

--- a/xmysqlnd/xmysqlnd_protocol_dumper.cc
+++ b/xmysqlnd/xmysqlnd_protocol_dumper.cc
@@ -407,8 +407,8 @@ xmysqlnd_dump_client_message(const zend_uchar packet_type, const void * payload,
 			DBG_INF_FMT("limit is %s", has_collection? "SET":"NOT SET");
 			if (has_limit) {
 				const Mysqlx::Crud::Limit & limit = message.limit();
-				DBG_INF_FMT("row_count[%s]=" MYSQLND_LLU_SPEC, limit.has_row_count()? "SET":"NOT SET", limit.has_row_count()? limit.row_count() :0);
-				DBG_INF_FMT("offset   [%s]=" MYSQLND_LLU_SPEC, limit.has_offset()? "SET":"NOT SET", limit.has_offset()? limit.offset() :0);
+				DBG_INF_FMT("row_count[%s]=" PRIu64, limit.has_row_count()? "SET":"NOT SET", limit.has_row_count()? limit.row_count() :0);
+				DBG_INF_FMT("offset   [%s]=" PRIu64, limit.has_offset()? "SET":"NOT SET", limit.has_offset()? limit.offset() :0);
 			}
 
 			DBG_INF_FMT("order_size=%d", message.order_size());
@@ -507,8 +507,8 @@ xmysqlnd_dump_client_message(const zend_uchar packet_type, const void * payload,
 			DBG_INF_FMT("limit is %s", has_collection? "SET":"NOT SET");
 			if (has_limit) {
 				const Mysqlx::Crud::Limit & limit = message.limit();
-				DBG_INF_FMT("row_count[%s]=" MYSQLND_LLU_SPEC, limit.has_row_count()? "SET":"NOT SET", limit.has_row_count()? limit.row_count() :0);
-				DBG_INF_FMT("offset   [%s]=" MYSQLND_LLU_SPEC, limit.has_offset()? "SET":"NOT SET", limit.has_offset()? limit.offset() :0);
+				DBG_INF_FMT("row_count[%s]=" PRIu64, limit.has_row_count()? "SET":"NOT SET", limit.has_row_count()? limit.row_count() :0);
+				DBG_INF_FMT("offset   [%s]=" PRIu64, limit.has_offset()? "SET":"NOT SET", limit.has_offset()? limit.offset() :0);
 			}
 
 			DBG_INF_FMT("order_size=%d", message.order_size());
@@ -569,8 +569,8 @@ xmysqlnd_dump_client_message(const zend_uchar packet_type, const void * payload,
 			DBG_INF_FMT("limit is %s", has_collection? "SET":"NOT SET");
 			if (has_limit) {
 				const Mysqlx::Crud::Limit & limit = message.limit();
-				DBG_INF_FMT("row_count[%s]=" MYSQLND_LLU_SPEC, limit.has_row_count()? "SET":"NOT SET", limit.has_row_count()? limit.row_count() :0);
-				DBG_INF_FMT("offset   [%s]=" MYSQLND_LLU_SPEC, limit.has_offset()? "SET":"NOT SET", limit.has_offset()? limit.offset() :0);
+				DBG_INF_FMT("row_count[%s]=" PRIu64, limit.has_row_count()? "SET":"NOT SET", limit.has_row_count()? limit.row_count() :0);
+				DBG_INF_FMT("offset   [%s]=" PRIu64, limit.has_offset()? "SET":"NOT SET", limit.has_offset()? limit.offset() :0);
 			}
 
 			DBG_INF_FMT("order_size=%d", message.order_size());
@@ -641,7 +641,7 @@ xmysqlnd_dump_column_meta(const Mysqlx::Resultset::ColumnMetaData & meta)
 									   has_catalog? meta.catalog().c_str() : "n/a");
 
 	const bool has_collation = meta.has_collation();
-	DBG_INF_FMT("collation[%s] is [" MYSQLND_LLU_SPEC "]", has_collation? "SET":"NOT SET",
+	DBG_INF_FMT("collation[%s] is [" PRIu64 "]", has_collation? "SET":"NOT SET",
 														 has_collation? meta.collation() : 0);
 
 	const bool has_frac_digits = meta.has_fractional_digits();

--- a/xmysqlnd/xmysqlnd_rowset_fwd.cc
+++ b/xmysqlnd/xmysqlnd_rowset_fwd.cc
@@ -54,7 +54,7 @@ XMYSQLND_METHOD(xmysqlnd_rowset_fwd, next)(XMYSQLND_ROWSET_FWD * const result,
 {
 	const zend_bool no_more_on_the_line = !result->stmt->get_msg_stmt_exec().reader_ctx.has_more_rows_in_set;
 	DBG_ENTER("xmysqlnd_rowset_fwd::next");
-	DBG_INF_FMT("row_cursor=" MYSQLND_LLU_SPEC "  row_count=" MYSQLND_LLU_SPEC, result->row_cursor, result->row_count);
+	DBG_INF_FMT("row_cursor=" PRIu64 "  row_count=" PRIu64, result->row_cursor, result->row_count);
 
 	if ((result->row_count - result->row_cursor) == 1 && !no_more_on_the_line) {
 		DBG_INF_FMT("We have to prefetch %u row(s)", result->prefetch_rows);
@@ -101,7 +101,7 @@ XMYSQLND_METHOD(xmysqlnd_rowset_fwd, fetch_one)(XMYSQLND_ROWSET_FWD * const resu
 	const unsigned int field_count = result->meta->m->get_field_count(result->meta);
 	const size_t row_count = result->row_count;
 	DBG_ENTER("xmysqlnd_rowset_fwd::fetch_one");
-	DBG_INF_FMT("row_cursor=" MYSQLND_LLU_SPEC "  row_count=" MYSQLND_LLU_SPEC, result->row_cursor, result->row_count);
+	DBG_INF_FMT("row_cursor=" PRIu64 "  row_count=" PRIu64, result->row_cursor, result->row_count);
 	if (row_cursor >= row_count || !result->rows[row_cursor]) {
 		DBG_RETURN(FAIL);
 	}
@@ -153,7 +153,7 @@ XMYSQLND_METHOD(xmysqlnd_rowset_fwd, fetch_all)(XMYSQLND_ROWSET_FWD * const resu
 		/* Remove what we have, as we don't need it anymore */
 		result->m.free_rows_contents(result, stats, error_info);
 	}
-	DBG_INF_FMT("total_row_count=" MYSQLND_LLU_SPEC, result->total_row_count);
+	DBG_INF_FMT("total_row_count=" PRIu64, result->total_row_count);
 	DBG_RETURN(PASS);
 }
 /* }}} */

--- a/xmysqlnd/xmysqlnd_session.cc
+++ b/xmysqlnd/xmysqlnd_session.cc
@@ -1057,7 +1057,7 @@ xmysqlnd_session_data_set_client_id(void * context, const size_t id)
 	enum_func_status ret{FAIL};
 	xmysqlnd_session_data * session = (xmysqlnd_session_data *) context;
 	DBG_ENTER("xmysqlnd_session_data_set_client_id");
-	DBG_INF_FMT("id=" MYSQLND_LLU_SPEC, id);
+	DBG_INF_FMT("id=" PRIu64, id);
 	if (context) {
 		session->client_id = id;
 		ret = PASS;

--- a/xmysqlnd/xmysqlnd_stmt.cc
+++ b/xmysqlnd/xmysqlnd_stmt.cc
@@ -161,7 +161,7 @@ static const enum_hnd_func_status handler_on_row_field(void * context,
 
 				ctx->rowset->m.destroy_row(ctx->rowset, ctx->current_row, ctx->stats, ctx->error_info);
 			} else {
-				DBG_INF_FMT("fwd_prefetch_count=" MYSQLND_LLU_SPEC " prefetch_counter=" MYSQLND_LLU_SPEC, ctx->fwd_prefetch_count, ctx->prefetch_counter);
+				DBG_INF_FMT("fwd_prefetch_count=" PRIu64 " prefetch_counter=" PRIu64, ctx->fwd_prefetch_count, ctx->prefetch_counter);
 				ctx->rowset->m.add_row(ctx->rowset, ctx->current_row, ctx->stats, ctx->error_info);
 				if (ctx->fwd_prefetch_count && !--ctx->prefetch_counter) {
 					ret = HND_PASS; /* Otherwise it is HND_AGAIN */
@@ -611,7 +611,7 @@ xmysqlnd_stmt::get_fwd_result(xmysqlnd_stmt * const stmt,
 	const struct st_xmysqlnd_on_stmt_execute_ok_bind on_stmt_execute_ok = { nullptr, nullptr };
 	const struct st_xmysqlnd_on_resultset_end_bind on_resultset_end = { nullptr, nullptr };
 	DBG_ENTER("xmysqlnd_stmt::get_fwd_result");
-	DBG_INF_FMT("rows=" MYSQLND_LLU_SPEC, rows);
+	DBG_INF_FMT("rows=" PRIu64, rows);
 
 	if (FALSE == stmt->partial_read_started) {
 		read_ctx.stmt = stmt;

--- a/xmysqlnd/xmysqlnd_stmt_execution_state.cc
+++ b/xmysqlnd/xmysqlnd_stmt_execution_state.cc
@@ -97,7 +97,7 @@ static void
 XMYSQLND_METHOD(xmysqlnd_stmt_execution_state, set_affected_items_count)(XMYSQLND_STMT_EXECUTION_STATE * const state, const size_t value)
 {
 	DBG_ENTER("xmysqlnd_stmt_execution_state::set_affected_items_count");
-	DBG_INF_FMT("value=" MYSQLND_LLU_SPEC, value);
+	DBG_INF_FMT("value=" PRIu64, value);
 	state->items_affected = value;
 	DBG_VOID_RETURN;
 }
@@ -109,7 +109,7 @@ static void
 XMYSQLND_METHOD(xmysqlnd_stmt_execution_state, set_matched_items_count)(XMYSQLND_STMT_EXECUTION_STATE * const state, const size_t value)
 {
 	DBG_ENTER("xmysqlnd_stmt_execution_state::set_matched_items_count");
-	DBG_INF_FMT("value=" MYSQLND_LLU_SPEC, value);
+	DBG_INF_FMT("value=" PRIu64, value);
 	state->items_matched = value;
 	DBG_VOID_RETURN;
 }
@@ -121,7 +121,7 @@ static void
 XMYSQLND_METHOD(xmysqlnd_stmt_execution_state, set_found_items_count)(XMYSQLND_STMT_EXECUTION_STATE * const state, const size_t value)
 {
 	DBG_ENTER("xmysqlnd_stmt_execution_state::set_found_items_count");
-	DBG_INF_FMT("value=" MYSQLND_LLU_SPEC, value);
+	DBG_INF_FMT("value=" PRIu64, value);
 	state->items_found = value;
 	DBG_VOID_RETURN;
 }
@@ -145,7 +145,7 @@ static void
 XMYSQLND_METHOD(xmysqlnd_stmt_execution_state, set_last_insert_id)(XMYSQLND_STMT_EXECUTION_STATE * const state, const uint64_t value)
 {
 	DBG_ENTER("xmysqlnd_stmt_execution_state::set_last_insert_id");
-	DBG_INF_FMT("value=" MYSQLND_LLU_SPEC, value);
+	DBG_INF_FMT("value=" PRIu64, value);
 	state->last_insert_id = value;
 	DBG_VOID_RETURN;
 }

--- a/xmysqlnd/xmysqlnd_stmt_result.cc
+++ b/xmysqlnd/xmysqlnd_stmt_result.cc
@@ -224,7 +224,7 @@ XMYSQLND_METHOD(xmysqlnd_stmt_result, get_row_count)(const XMYSQLND_STMT_RESULT 
 	if (result->rowset) {
 		ret = result->rowset->m.get_row_count(result->rowset);
 	}
-	DBG_INF_FMT("rows=" MYSQLND_LLU_SPEC, ret);
+	DBG_INF_FMT("rows=" PRIu64, ret);
 	DBG_RETURN(ret);
 }
 /* }}} */

--- a/xmysqlnd/xmysqlnd_wireprotocol.cc
+++ b/xmysqlnd/xmysqlnd_wireprotocol.cc
@@ -1347,15 +1347,15 @@ enum_func_status xmysqlnd_row_time_field_to_zval( zval* zv,
 		} else {
 			do {
 				if (!util::pb::read_variant_64(input_stream, &neg)) break;
-				DBG_INF_FMT("neg     =" MYSQLND_LLU_SPEC, neg);
+				DBG_INF_FMT("neg     =" PRIu64, neg);
 				if (!util::pb::read_variant_64(input_stream, &hours)) break;
-				DBG_INF_FMT("hours   =" MYSQLND_LLU_SPEC, hours);
+				DBG_INF_FMT("hours   =" PRIu64, hours);
 				if (!util::pb::read_variant_64(input_stream, &minutes)) break;
-				DBG_INF_FMT("mins    =" MYSQLND_LLU_SPEC, minutes);
+				DBG_INF_FMT("mins    =" PRIu64, minutes);
 				if (!util::pb::read_variant_64(input_stream, &seconds)) break;
-				DBG_INF_FMT("secs    =" MYSQLND_LLU_SPEC, seconds);
+				DBG_INF_FMT("secs    =" PRIu64, seconds);
 				if (!util::pb::read_variant_64(input_stream, &useconds)) break;
-				DBG_INF_FMT("usecs   =" MYSQLND_LLU_SPEC, useconds);
+				DBG_INF_FMT("usecs   =" PRIu64, useconds);
 			} while (0);
 
 			auto str = util::formatter("%s%02u:%02u:%02u.%08u")
@@ -1395,19 +1395,19 @@ enum_func_status xmysqlnd_row_datetime_field_to_zval( zval* zv,
 		} else {
 			do {
 				if (!util::pb::read_variant_64(input_stream, &year)) break;
-				DBG_INF_FMT("year    =" MYSQLND_LLU_SPEC, year);
+				DBG_INF_FMT("year    =" PRIu64, year);
 				if (!util::pb::read_variant_64(input_stream, &month)) break;
-				DBG_INF_FMT("month   =" MYSQLND_LLU_SPEC, month);
+				DBG_INF_FMT("month   =" PRIu64, month);
 				if (!util::pb::read_variant_64(input_stream, &day)) break;
-				DBG_INF_FMT("day     =" MYSQLND_LLU_SPEC, day);
+				DBG_INF_FMT("day     =" PRIu64, day);
 				if (!util::pb::read_variant_64(input_stream, &hours)) break;
-				DBG_INF_FMT("hours   =" MYSQLND_LLU_SPEC, hours);
+				DBG_INF_FMT("hours   =" PRIu64, hours);
 				if (!util::pb::read_variant_64(input_stream, &minutes)) break;
-				DBG_INF_FMT("mins    =" MYSQLND_LLU_SPEC, minutes);
+				DBG_INF_FMT("mins    =" PRIu64, minutes);
 				if (!util::pb::read_variant_64(input_stream, &seconds)) break;
-				DBG_INF_FMT("secs    =" MYSQLND_LLU_SPEC, seconds);
+				DBG_INF_FMT("secs    =" PRIu64, seconds);
 				if (!util::pb::read_variant_64(input_stream, &useconds)) break;
-				DBG_INF_FMT("usecs   =" MYSQLND_LLU_SPEC, useconds);
+				DBG_INF_FMT("usecs   =" PRIu64, useconds);
 			} while (0);
 
 			auto str = util::formatter("%04u-%02u-%02u %02u:%02u:%02u")
@@ -1450,11 +1450,11 @@ enum_func_status xmysqlnd_row_date_field_to_zval(
 		} else {
 			do {
 				if (!util::pb::read_variant_64(input_stream, &year)) break;
-				DBG_INF_FMT("year  =" MYSQLND_LLU_SPEC, year);
+				DBG_INF_FMT("year  =" PRIu64, year);
 				if (!util::pb::read_variant_64(input_stream, &month)) break;
-				DBG_INF_FMT("month =" MYSQLND_LLU_SPEC, month);
+				DBG_INF_FMT("month =" PRIu64, month);
 				if (!util::pb::read_variant_64(input_stream, &day)) break;
-				DBG_INF_FMT("day   =" MYSQLND_LLU_SPEC, day);
+				DBG_INF_FMT("day   =" PRIu64, day);
 			} while (0);
 
 			auto str = util::formatter("%04u-%02u-%02u")

--- a/xmysqlnd/xmysqlnd_zval2any.cc
+++ b/xmysqlnd/xmysqlnd_zval2any.cc
@@ -382,10 +382,10 @@ scalar2string(const Mysqlx::Datatypes::Scalar & scalar)
 	DBG_INF_FMT("subtype=%s", Scalar::Type_Name(scalar.type()).c_str());
 	switch (scalar.type()) {
 		case Scalar_Type_V_SINT:
-			ret.l = mnd_sprintf(&ret.s, 0, MYSQLND_LLU_SPEC, scalar.v_signed_int());
+			ret.l = mnd_sprintf(&ret.s, 0, PRIu64, scalar.v_signed_int());
 			break;
 		case Scalar_Type_V_UINT:
-			ret.l = mnd_sprintf(&ret.s, 0, MYSQLND_LLU_SPEC, scalar.v_unsigned_int());
+			ret.l = mnd_sprintf(&ret.s, 0, PRIu64, scalar.v_unsigned_int());
 			break;
 		case Scalar_Type_V_NULL:
 			break;
@@ -434,7 +434,7 @@ scalar2log(const Mysqlx::Datatypes::Scalar & scalar)
 			} else
 #endif
 			{
-				DBG_INF_FMT("value=" MYSQLND_LLU_SPEC, scalar.v_signed_int());
+				DBG_INF_FMT("value=" PRIu64, scalar.v_signed_int());
 			}
 			break;
 		case Scalar_Type_V_UINT:
@@ -447,7 +447,7 @@ scalar2log(const Mysqlx::Datatypes::Scalar & scalar)
 				snprintf(tmp, sizeof(tmp), "%s", util::to_string(scalar.v_unsigned_int()).c_str());
 				DBG_INF_FMT("value=%s", tmp);
 			} else {
-				DBG_INF_FMT("value=" MYSQLND_LLU_SPEC, scalar.v_unsigned_int());
+				DBG_INF_FMT("value=" PRIu64, scalar.v_unsigned_int());
 			}
 			break;
 		case Scalar_Type_V_NULL:


### PR DESCRIPTION
`MYSQLND_LLU_SPEC` have been removed from 7.4, but `PRIu64` exists since 7.0

And from UPGRADING.INTERNALS
```
  m. The write_property() object handler now returns the assigned value (after
     possible type coercions) rather than void. For extensions, it should
     usually be sufficient to return whatever was passed as the argument.


```