### PR TITLE
fix typo: mysqlx => mysqlx_x

### DIFF
--- a/mysqlx_session.cc
+++ b/mysqlx_session.cc
@@ -838,8 +838,7 @@ mysqlx_register_session_class(UNUSED_INIT_FUNC_ARGS, zend_object_handlers * mysq
 		zend_class_entry tmp_ce;
 		INIT_NS_CLASS_ENTRY(tmp_ce, "mysql_xdevapi", "Session", mysqlx_session_methods);
 		tmp_ce.create_object = php_mysqlx_session_object_allocator;
-		mysqlx_session_class_entry = zend_register_internal_class_ex(
-			&tmp_ce, mysqlx_session_class_entry);
+		mysqlx_session_class_entry = zend_register_internal_class(&tmp_ce);
 	}
 
 	zend_hash_init(&mysqlx_session_properties, 0, nullptr, mysqlx_free_property_cb, 1);

--- a/mysqlx_x_session.cc
+++ b/mysqlx_x_session.cc
@@ -75,8 +75,7 @@ mysqlx_register_x_session_class(UNUSED_INIT_FUNC_ARGS, zend_object_handlers * /*
 	{
 		zend_class_entry tmp_ce;
 		INIT_NS_CLASS_ENTRY(tmp_ce, "mysql_xdevapi", "XSession", mysqlx_x_session_methods);
-		mysqlx_x_session_class_entry = zend_register_internal_class_ex(
-			&tmp_ce, mysqlx_x_session_class_entry);
+		mysqlx_x_session_class_entry = zend_register_internal_class(&tmp_ce);
 	}
 
 	zend_hash_init(&mysqlx_x_session_properties, 0, nullptr, mysqlx_free_property_cb, 1);

--- a/mysqlx_x_session.cc
+++ b/mysqlx_x_session.cc
@@ -76,7 +76,7 @@ mysqlx_register_x_session_class(UNUSED_INIT_FUNC_ARGS, zend_object_handlers * /*
 		zend_class_entry tmp_ce;
 		INIT_NS_CLASS_ENTRY(tmp_ce, "mysql_xdevapi", "XSession", mysqlx_x_session_methods);
 		mysqlx_x_session_class_entry = zend_register_internal_class_ex(
-			&tmp_ce, mysqlx_session_class_entry);
+			&tmp_ce, mysqlx_x_session_class_entry);
 	}
 
 	zend_hash_init(&mysqlx_x_session_properties, 0, nullptr, mysqlx_free_property_cb, 1);


### PR DESCRIPTION
This looks like a simple typo to me, can't find any reference in the docs that XSession actually inherits Session